### PR TITLE
remove seconds to time input formats

### DIFF
--- a/lynbrook_app/settings.py
+++ b/lynbrook_app/settings.py
@@ -122,7 +122,7 @@ LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "America/Los_Angeles"
 
-TIME_INPUT_FORMATS= ['%H:%M',]# '14:30'
+TIME_INPUT_FORMATS= ["%H:%M"]
 
 USE_I18N = True
 

--- a/lynbrook_app/settings.py
+++ b/lynbrook_app/settings.py
@@ -122,6 +122,8 @@ LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "America/Los_Angeles"
 
+TIME_INPUT_FORMATS= ['%H:%M',]# '14:30'
+
 USE_I18N = True
 
 USE_L10N = True


### PR DESCRIPTION
time format is primarily for club events  ( most of which are club meetings) 

No club meetings will ever need to be specific enough to warrant including seconds. Please remove it and help solve some initial confusion when using Lynbrook app